### PR TITLE
 🔀 merge request : chats to main

### DIFF
--- a/templates/post-detail.html
+++ b/templates/post-detail.html
@@ -228,6 +228,7 @@
                         <div class="d-flex align-items-center">
                             <img src="" alt="Profile" class="rounded-circle me-2" width="40" height="40" id="user-profile-image">
                             <h5 class="mb-0" id="username"></h5>
+							<span id="post-location" class="ms-3"></span>
                         </div>
                     </div>
                     <div class="card-body">
@@ -254,7 +255,7 @@
                               <div id="likes-count" class="mb-2"></div>
                               <div id="likes-list" class="mb-3"></div>
                           </div>
-                            <span id="post-location"></span>
+                            
                         </div>
                         <div class="mt-3" id="tags-container">
                             <!-- 태그는 여기에 동적으로 추가됩니다 -->

--- a/templates/post-detail.js
+++ b/templates/post-detail.js
@@ -76,7 +76,7 @@
                         const reportButton = document.createElement('div');
                         reportButton.className = 'mt-3';
                         reportButton.innerHTML = `
-                            <button class="btn btn-warning btn-sm" onclick="window.location.href='/templates/report-form.html?content_type=posts.post&object_id=${postId}'">
+                            <button class="btn btn-danger-soft btn-sm" onclick="window.location.href='/templates/report-form.html?content_type=posts.post&object_id=${postId}'">
                                 <i class="bi bi-exclamation-triangle-fill"></i> 신고
                             </button>
                         `;

--- a/templates/product-detail.html
+++ b/templates/product-detail.html
@@ -265,7 +265,7 @@
                     </div>
 
                     <div class="report-button-container">
-                        <button id="report-button" class="bi bi-exclamation-triangle-fill fa-fw, btn btn-warning"> 신고</button>
+                        <button id="report-button" class="bi bi-exclamation-triangle-fill fa-fw, btn btn-danger-soft"> 신고</button>
                     </div>
 
                     <a href="product-list.html" class="btn btn-secondary mt-4">목록으로 돌아가기</a>


### PR DESCRIPTION
🎨 style: post-detail location 위치 조정

- 게시글 작성자 이름 옆으로 이동

🎨 style: 신고 버튼 수정

- 기존의 warning 버튼에서 danger 버튼으로 변경

아마 삭제 버튼과 신고 버튼을 구분하기 위해 신고 버튼을 warning 버튼(노란색)으로 설정한 것 같은데, 삭제 버튼과 신고 버튼이 동시에 보여질 일은 없으니(삭제 버튼은 자신이 작성한 글에만 보이고, 신고 버튼은 자신이 작성한 글에 나타나지 않음) 신고 버튼을 사용자에게 좀 더 익숙할 빨간색으로 변경했습니다. 혹시 다른 이유가 있었던 것이라면 댓글로 남겨주세요
